### PR TITLE
modify: 커뮤니티 생성시 이미지 업로드 관련 수정

### DIFF
--- a/src/pages/Board/BoardList.tsx
+++ b/src/pages/Board/BoardList.tsx
@@ -7,6 +7,7 @@ import { useSelector } from 'react-redux';
 import { RootState } from '../../store/store';
 import EmptyState from '../../components/EmptyState';
 import { useInView } from 'react-intersection-observer';
+import styled from 'styled-components';
 
 interface ContainerProps {
   children?: React.ReactNode;
@@ -154,6 +155,7 @@ const BoardList = () => {
   return (
     <>
       <MainContainer>
+        {buttonType !== 'HOME' || 'POPULAR' ||  'TAGMATCH'}
         <CardsContainer>
           {list.length ? (
             list.map((el: CardType, index) => {
@@ -185,4 +187,11 @@ const BoardList = () => {
   );
 };
 
-export default BoardList;
+export default BoardList; 
+
+const BackgroundImageContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  max-height: 350px;
+
+`

--- a/src/pages/Board/CommunityCreate/CommunityCreatePage1.tsx
+++ b/src/pages/Board/CommunityCreate/CommunityCreatePage1.tsx
@@ -22,6 +22,10 @@ const CommunityCreatePage1: FC = () => {
     setProfilePicture,
     backgroundPicture,
     setBackgroundPicture,
+    banner,
+    setBanner,
+    icon,
+    setIcon
   } = useCommunity();
   const [textareaHeight, setTextareaHeight] = useState('120px');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -66,6 +70,7 @@ const CommunityCreatePage1: FC = () => {
         await AwsImageUploadFunctionality({ fileList: [profilePicture] });
       if (!profileRes) return;
       setProfilePicture(profileRes.imageUrls[0]);
+      setIcon(profileRes.imageUrls[0])
     }
 
     if (backgroundPicture && typeof backgroundPicture !== 'string') {
@@ -73,6 +78,7 @@ const CommunityCreatePage1: FC = () => {
         await AwsImageUploadFunctionality({ fileList: [backgroundPicture] });
       if (!backgroundRes) return;
       setBackgroundPicture(backgroundRes.imageUrls[0]);
+      setBanner(backgroundRes.imageUrls[0]);
     }
 
     navigate('/community/create3', { state: { communityName, description } });

--- a/src/pages/Board/CommunityCreate/CommunityCreatePage4.tsx
+++ b/src/pages/Board/CommunityCreate/CommunityCreatePage4.tsx
@@ -18,13 +18,15 @@ const CommunityCreatePage4: FC = () => {
   }
   
   const navigate = useNavigate();
-  const { communityName, description, banner, icon, topics } = useCommunity();
+  const { communityName, description, banner, icon, topics,backgroundPicture } = useCommunity();
   const [visibility, setVisibility] =
     useState<CommunityVisibilityType>('PUBLIC');
   const [searchNickname, setSearchNickname] = useState<string>('')
   const [searchResultList, setSearchResultList] = useState<User[]>([]);
   const userId = localStorage.getItem('id') as string;
-
+  console.log(communityName);
+  console.log(backgroundPicture);
+  console.log(icon)
   useEffect(() => {
     setIsCommunity((prevState) => ({...prevState, id : [userId], visibility: visibility}))
   }, [visibility]);

--- a/src/pages/Global/GlobalSideBar.tsx
+++ b/src/pages/Global/GlobalSideBar.tsx
@@ -45,7 +45,7 @@ const GlobalSideBar = () => {
       const res = await CommunityListAPI({ take: 10, page });
       if (!res) return;
       const response = res.data.response.current_list;
-
+      console.log(response);
       const uniqueCommunities = response.filter((community: CommunityType) => {
         if (communityNamesSet.has(community.name)) {
           return false;


### PR DESCRIPTION
커뮤니티 생성시 s3에 이미지를 업로드한 후 반환받은 값을 이용하여 배경화면과 프로필 사진을 string형식으로 전달해줘야 하는데 해당 로직이 제대로 구현되어 있지 않아
배경화면과 프로필 사진이 업로드 되지 않던 이슈 해결